### PR TITLE
Rda 18 implement order history table with full order details

### DIFF
--- a/src/__tests__/profile/ProfilePage.test.tsx
+++ b/src/__tests__/profile/ProfilePage.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    order: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+    account: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as unknown as { auth: unknown }).auth as ReturnType<typeof vi.fn>),
+    prisma: (dbMod as unknown as { prisma: unknown }).prisma as {
+      order: { findMany: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn> };
+      account: { findMany: ReturnType<typeof vi.fn> };
+    },
+  };
+}
+
+type TestItem = { quantity: number; priceCentsAtPurchase: number; item: { name: string } };
+type TestOrder = {
+  id: string;
+  createdAt: Date;
+  status: string;
+  totalCents: number;
+  restaurant: { name: string };
+  items: TestItem[];
+};
+
+function makeOrder(overrides?: Partial<TestOrder>): TestOrder {
+  return {
+    id: 'aaaaaaaa-1111-2222-3333',
+    createdAt: new Date('2024-01-02T10:00:00Z'),
+    status: 'COMPLETED',
+    totalCents: 2599,
+    restaurant: { name: 'Test Resto' },
+    items: [
+      { quantity: 1, priceCentsAtPurchase: 1599, item: { name: 'Burger' } },
+      { quantity: 1, priceCentsAtPurchase: 1000, item: { name: 'Fries' } },
+    ],
+    ...overrides,
+  };
+}
+
+describe('ProfilePage order history', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('renders order rows for the signed-in user', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1', name: 'Alice', email: 'a@example.com' } });
+    prisma.order.findMany.mockResolvedValue([makeOrder(), makeOrder({ id: 'bbbbbbbb-xxxx' })]);
+    prisma.order.count.mockResolvedValue(2);
+    prisma.account.findMany.mockResolvedValue([
+      { provider: 'github', providerAccountId: '123' },
+      { provider: 'google', providerAccountId: '456' },
+    ]);
+
+    const { default: ProfilePage } = await import('@/app/profile/page');
+    const el = await ProfilePage({ searchParams: {} });
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+
+    expect(html).toContain('Order History');
+    expect(html).toContain('Test Resto');
+    expect(html).toContain('#aaaaaaaa');
+    expect(html).toContain('€25.99');
+  });
+
+  it('shows empty state when user has no orders', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } });
+    prisma.order.findMany.mockResolvedValue([]);
+    prisma.order.count.mockResolvedValue(0);
+    prisma.account.findMany.mockResolvedValue([]);
+
+    const { default: ProfilePage } = await import('@/app/profile/page');
+    const el = await ProfilePage({ searchParams: {} });
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+
+    expect(html).toContain('No orders yet');
+  });
+
+  it('renders pagination controls when there are more pages', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } });
+    prisma.order.findMany.mockResolvedValue(
+      Array.from({ length: 20 }, (_, i) => makeOrder({ id: `id-${i}` })),
+    );
+    prisma.order.count.mockResolvedValue(25);
+    prisma.account.findMany.mockResolvedValue([]);
+
+    const { default: ProfilePage } = await import('@/app/profile/page');
+    const el = await ProfilePage({ searchParams: {} });
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+
+    expect(html).toContain('Next');
+    expect(html).toContain('/profile?page=2');
+  });
+});

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,75 +1,151 @@
-'use client';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+// format helpers used by OrderTable; page imports only its component
+import OrderTable from '@/components/profile/OrderTable';
 
-import { useSession, signIn } from 'next-auth/react';
-import { useState, useEffect } from 'react';
+type OrderRow = {
+  id: string;
+  createdAt: Date;
+  status: string;
+  totalCents: number;
+  restaurant: { name: string } | null;
+  items: {
+    quantity: number;
+    priceCentsAtPurchase: number;
+    item: { name: string } | null;
+  }[];
+};
 
-export default function Profile() {
-  const { data: session, status } = useSession();
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
-    setIsLoaded(true);
-  }, []);
-
-  // Handle loading state
-  if (status === 'loading' || !isLoaded) {
-    return <div className="mx-auto max-w-4xl p-8">Loading...</div>;
-  }
-
-  // Handle unauthenticated state
-  if (status === 'unauthenticated') {
+export default async function ProfilePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ page?: string }>;
+}) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    // This path should normally be handled by middleware; add a friendly message as fallback.
     return (
-      <div className="mx-auto max-w-4xl p-8 text-center">
-        <h1 className="mb-6 text-2xl font-bold">Authentication Required</h1>
-        <p className="mb-4">You need to be signed in to view your profile.</p>
-        <button
-          onClick={() => signIn()}
-          className="rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
-        >
-          Sign In
-        </button>
+      <div className="mx-auto max-w-6xl p-8 text-center">
+        <h1 className="mb-4 text-2xl font-bold">Please sign in</h1>
+        <p>Sign in to view your profile and order history.</p>
       </div>
     );
   }
 
+  const pageSize = 20;
+  const params = await searchParams;
+  const page = Math.max(1, Number(params?.page) || 1);
+  const skip = (page - 1) * pageSize;
+
+  const [orders, totalCount, accounts] = await Promise.all([
+    prisma.order.findMany({
+      where: { customerId: session.user.id },
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take: pageSize,
+      select: {
+        id: true,
+        createdAt: true,
+        status: true,
+        totalCents: true,
+        restaurant: { select: { name: true } },
+        items: {
+          select: {
+            quantity: true,
+            priceCentsAtPurchase: true,
+            item: { select: { name: true } },
+          },
+        },
+      },
+    }) as Promise<OrderRow[]>,
+    prisma.order.count({ where: { customerId: session.user.id } }),
+    prisma.account.findMany({
+      where: { userId: session.user.id },
+      select: { provider: true, providerAccountId: true },
+    }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
   return (
-    <div className="mx-auto max-w-4xl p-8">
+    <div className="mx-auto max-w-6xl p-8">
       <h1 className="mb-6 text-2xl font-bold">Your Profile</h1>
 
-      <div className="rounded-lg bg-white p-6 shadow">
-        <div className="mb-6 flex items-center space-x-6">
-          {session?.user?.image ? (
+      <section className="mb-8 rounded-lg bg-white p-6 shadow">
+        <div className="mb-6 flex items-center gap-6">
+          {session.user.image ? (
             <>
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={session.user.image}
                 alt={session.user.name || 'User'}
-                className="h-24 w-24 rounded-full"
+                className="h-20 w-20 rounded-full"
               />
             </>
           ) : (
-            <div className="flex h-24 w-24 items-center justify-center rounded-full bg-gray-200 text-2xl font-bold text-gray-500">
-              {session?.user?.name?.[0] || 'U'}
+            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-gray-200 text-2xl font-bold text-gray-500">
+              {session.user.name?.[0] || 'U'}
             </div>
           )}
-
           <div>
-            <h2 className="text-xl font-medium">{session?.user?.name || 'User'}</h2>
-            <p className="text-gray-600">{session?.user?.email || ''}</p>
+            <h2 className="text-xl font-medium">{session.user.name || 'User'}</h2>
+            <p className="text-gray-600">{session.user.email || ''}</p>
           </div>
         </div>
 
         <div className="border-t pt-4">
           <h3 className="mb-2 font-medium">Connected Accounts</h3>
-          <ul className="space-y-2">
-            {session?.user?.accounts?.map((account) => (
-              <li key={account.provider} className="flex items-center">
-                <span className="text-gray-600">{account.provider}</span>
-              </li>
-            ))}
-          </ul>
+          {accounts && accounts.length > 0 ? (
+            <ul className="grid grid-cols-2 gap-y-1 text-sm text-gray-800">
+              {accounts.map((a, i) => (
+                <li key={`${a.provider}-${i}`} className="flex items-center gap-2">
+                  <span className="inline-block h-2 w-2 rounded-full bg-gray-400" />
+                  <span className="capitalize">{a.provider}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-gray-600">No connected accounts.</p>
+          )}
         </div>
-      </div>
+      </section>
+
+      <section className="rounded-lg bg-white p-6 shadow">
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-semibold">Order History</h2>
+          <span className="text-sm text-gray-500">
+            {totalCount} order{totalCount === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        <OrderTable orders={orders} />
+
+        {totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <a
+              className={`rounded border px-3 py-1 text-sm ${
+                page <= 1 ? 'pointer-events-none opacity-50' : 'hover:bg-gray-50'
+              }`}
+              href={`/profile?page=${page - 1}`}
+              aria-disabled={page <= 1}
+            >
+              Previous
+            </a>
+            <span className="text-sm text-gray-600">
+              Page {page} of {totalPages}
+            </span>
+            <a
+              className={`rounded border px-3 py-1 text-sm ${
+                page >= totalPages ? 'pointer-events-none opacity-50' : 'hover:bg-gray-50'
+              }`}
+              href={`/profile?page=${page + 1}`}
+              aria-disabled={page >= totalPages}
+            >
+              Next
+            </a>
+          </div>
+        )}
+      </section>
     </div>
   );
 }

--- a/src/components/profile/OrderTable.tsx
+++ b/src/components/profile/OrderTable.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { Fragment, useId, useState } from 'react';
+import { formatCents, formatDateTime } from '@/lib/format';
+
+export type OrderRow = {
+  id: string;
+  createdAt: Date | string;
+  status: string;
+  totalCents: number;
+  restaurant: { name: string } | null;
+  items: { quantity: number; priceCentsAtPurchase: number; item: { name: string } | null }[];
+};
+
+export function OrderTable({ orders }: { orders: OrderRow[] }) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const baseId = useId();
+
+  const toggle = (id: string) => setOpen((s) => ({ ...s, [id]: !s[id] }));
+
+  if (orders.length === 0) {
+    return (
+      <div className="rounded border border-dashed p-8 text-center text-gray-600">
+        No orders yet.
+      </div>
+    );
+  }
+
+  return (
+    <table className="w-full table-fixed border-collapse text-left text-sm">
+      <colgroup>
+        <col className="w-[16%]" />
+        <col className="w-[20%]" />
+        <col className="w-[22%]" />
+        <col className="w-[10%]" />
+        <col className="w-[12%]" />
+        <col className="w-[20%]" />
+      </colgroup>
+      <thead>
+        <tr className="border-b text-gray-600">
+          <th className="py-2">Order</th>
+          <th className="py-2">Date</th>
+          <th className="py-2">Restaurant</th>
+          <th className="py-2">Items</th>
+          <th className="py-2">Status</th>
+          <th className="py-2">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        {orders.map((o, idx) => {
+          const itemsCount = o.items.reduce((n, it) => n + (it.quantity || 0), 0);
+          const shortId = o.id.slice(0, 8);
+          const detailsId = `${baseId}-${idx}`;
+          const isOpen = !!open[o.id];
+          return (
+            <Fragment key={o.id}>
+              <tr className="border-b align-top">
+                <td className="py-3 font-mono text-xs text-gray-700">
+                  <button
+                    type="button"
+                    aria-expanded={isOpen}
+                    aria-controls={detailsId}
+                    onClick={() => toggle(o.id)}
+                    className="mr-2 inline-flex h-5 w-5 items-center justify-center rounded border text-gray-600 hover:bg-gray-50"
+                    data-testid={`expand-${o.id}`}
+                    title={isOpen ? 'Hide details' : 'Show details'}
+                  >
+                    {isOpen ? '−' : '+'}
+                  </button>
+                  #{shortId}
+                </td>
+                <td className="py-3 text-gray-800">{formatDateTime(new Date(o.createdAt))}</td>
+                <td className="py-3 text-gray-800">{o.restaurant?.name || '-'}</td>
+                <td className="py-3 text-gray-800">{itemsCount}</td>
+                <td className="py-3">
+                  <span
+                    className={
+                      'inline-flex items-center rounded px-2 py-0.5 text-xs ' +
+                      (o.status === 'COMPLETED'
+                        ? 'bg-green-100 text-green-800'
+                        : o.status === 'CANCELLED'
+                          ? 'bg-red-100 text-red-800'
+                          : 'bg-yellow-100 text-yellow-800')
+                    }
+                  >
+                    {o.status}
+                  </span>
+                </td>
+                <td className="py-3 font-medium text-gray-900">{formatCents(o.totalCents)}</td>
+              </tr>
+              {isOpen && (
+                <tr className="border-b bg-gray-50/50" aria-live="polite">
+                  <td id={detailsId} colSpan={6} className="py-3">
+                    <div className="px-2">
+                      <div className="mb-2 text-xs font-semibold text-gray-600 uppercase">
+                        Items
+                      </div>
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="text-gray-600">
+                            <th className="py-1 text-left">Name</th>
+                            <th className="py-1 text-left">Qty</th>
+                            <th className="py-1 text-left">Price</th>
+                            <th className="py-1 text-left">Line total</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {o.items.map((it, i) => {
+                            const lineTotal = (it.quantity || 0) * (it.priceCentsAtPurchase || 0);
+                            return (
+                              <tr key={i} className="">
+                                <td className="py-1 text-gray-800">{it.item?.name || '-'}</td>
+                                <td className="py-1 text-gray-800">{it.quantity}</td>
+                                <td className="py-1 text-gray-800">
+                                  {formatCents(it.priceCentsAtPurchase)}
+                                </td>
+                                <td className="py-1 font-medium text-gray-900">
+                                  {formatCents(lineTotal)}
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                      <div className="mt-3 border-t pt-2 text-right text-sm">
+                        <span className="mr-2 text-gray-600">Order total:</span>
+                        <span className="font-semibold text-gray-900">
+                          {formatCents(o.totalCents)}
+                        </span>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              )}
+            </Fragment>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export default OrderTable;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,24 @@
+export function formatCents(amountCents: number, locale = 'en-US', currency = 'EUR') {
+  try {
+    return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(
+      (amountCents || 0) / 100,
+    );
+  } catch {
+    // Fallback if currency/locale not supported
+    return `€${((amountCents || 0) / 100).toFixed(2)}`;
+  }
+}
+
+export function formatDateTime(dt: Date, locale = 'en-GB') {
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(dt));
+  } catch {
+    return new Date(dt).toISOString();
+  }
+}


### PR DESCRIPTION
Implemented the Profile page order history (desktop-only) with expandable per-item details, fixed Connected Accounts, and included pagination. 

**Changes:**

- Profile page : auth0 for enforcment, order fetching, order pagination.
- UI : table with expandable rows
- Utils: formatCents and formatDateTime helpers 
- Tests: mocked orders, checked empty state, pagination