### PR TITLE
Rda 26 implement order details page

### DIFF
--- a/src/__tests__/profile/OrderDetailsPage.test.tsx
+++ b/src/__tests__/profile/OrderDetailsPage.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    order: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as unknown as { auth: unknown }).auth as ReturnType<typeof vi.fn>),
+    prisma: (dbMod as unknown as { prisma: unknown }).prisma as {
+      order: { findUnique: ReturnType<typeof vi.fn> };
+    },
+  };
+}
+
+function makeOrder(overrides?: any) {
+  return {
+    id: 'ord_aaaaaaaa',
+    createdAt: new Date('2024-01-02T10:00:00Z'),
+    status: 'COMPLETED',
+    totalCents: 2599,
+    restaurant: { id: 'r1', name: 'Test Resto' },
+    user: { id: 'user-1' },
+    items: [
+      { quantity: 1, priceCentsAtPurchase: 1599, item: { id: 'i1', name: 'Burger' } },
+      { quantity: 1, priceCentsAtPurchase: 1000, item: { id: 'i2', name: 'Fries' } },
+    ],
+    checkout: {
+      id: 'chk_123',
+      createdAt: new Date('2024-01-02T10:00:10Z'),
+      subtotalCents: 2599,
+      taxCents: 0,
+      feeCents: 0,
+      totalCents: 2599,
+    },
+    ...overrides,
+  };
+}
+
+describe('OrderDetailsPage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('renders details for a user-owned order', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } });
+    prisma.order.findUnique.mockResolvedValue(makeOrder());
+
+    const { default: Page } = await import('@/app/profile/orders/[id]/page');
+    const el = await Page({ params: { id: 'ord_aaaaaaaa' } });
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+
+    expect(html).toContain('Order #ord_aaaa');
+    expect(html).toContain('Test Resto');
+    expect(html).toContain('€25.99');
+    expect(html).toContain('Payment session');
+  });
+
+  it('404s when order not found or not owned', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } });
+    prisma.order.findUnique.mockResolvedValue({ ...makeOrder(), user: { id: 'other' } });
+
+    const { default: Page } = await import('@/app/profile/orders/[id]/page');
+
+    let threw = false;
+    try {
+      await Page({ params: { id: 'ord_aaaaaaaa' } });
+    } catch (e) {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+  });
+
+  it('renders without checkout gracefully', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } });
+    prisma.order.findUnique.mockResolvedValue(makeOrder({ checkout: null }));
+
+    const { default: Page } = await import('@/app/profile/orders/[id]/page');
+    const el = await Page({ params: { id: 'ord_aaaaaaaa' } });
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+
+    expect(html).toContain('No payment information');
+  });
+});

--- a/src/__tests__/profile/ProfilePage.test.tsx
+++ b/src/__tests__/profile/ProfilePage.test.tsx
@@ -71,13 +71,15 @@ describe('ProfilePage order history', () => {
     ]);
 
     const { default: ProfilePage } = await import('@/app/profile/page');
-    const el = await ProfilePage({ searchParams: {} });
+    const el = await ProfilePage({ searchParams: Promise.resolve({}) as any });
     const html = renderToStaticMarkup(el as unknown as React.ReactElement);
 
     expect(html).toContain('Order History');
     expect(html).toContain('Test Resto');
     expect(html).toContain('#aaaaaaaa');
     expect(html).toContain('€25.99');
+    // has a View link to details page
+    expect(html).toContain('/profile/orders/aaaaaaaa-1111-2222-3333');
   });
 
   it('shows empty state when user has no orders', async () => {
@@ -88,7 +90,7 @@ describe('ProfilePage order history', () => {
     prisma.account.findMany.mockResolvedValue([]);
 
     const { default: ProfilePage } = await import('@/app/profile/page');
-    const el = await ProfilePage({ searchParams: {} });
+    const el = await ProfilePage({ searchParams: Promise.resolve({}) as any });
     const html = renderToStaticMarkup(el as unknown as React.ReactElement);
 
     expect(html).toContain('No orders yet');
@@ -104,7 +106,7 @@ describe('ProfilePage order history', () => {
     prisma.account.findMany.mockResolvedValue([]);
 
     const { default: ProfilePage } = await import('@/app/profile/page');
-    const el = await ProfilePage({ searchParams: {} });
+    const el = await ProfilePage({ searchParams: Promise.resolve({}) as any });
     const html = renderToStaticMarkup(el as unknown as React.ReactElement);
 
     expect(html).toContain('Next');

--- a/src/app/profile/orders/[id]/page.tsx
+++ b/src/app/profile/orders/[id]/page.tsx
@@ -1,0 +1,189 @@
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+import { formatCents, formatDateTime } from '@/lib/format';
+import { notFound } from 'next/navigation';
+
+type OrderDetails = {
+  id: string;
+  createdAt: Date;
+  status: string;
+  totalCents: number;
+  restaurant: { id: string; name: string } | null;
+  items: {
+    quantity: number;
+    priceCentsAtPurchase: number;
+    item: { id: string; name: string } | null;
+  }[];
+  checkout: {
+    id: string;
+    createdAt: Date;
+    subtotalCents: number;
+    taxCents: number;
+    feeCents: number;
+    totalCents: number;
+  } | null;
+};
+
+export default async function OrderDetailsPage({
+  params,
+}: {
+  params: Promise<{ id: string }> | { id: string };
+}) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    // Normally gated by middleware; fail closed here.
+    notFound();
+  }
+
+  const p = await params;
+  const orderId = (p as { id: string }).id;
+
+  const order = (await prisma.order.findUnique({
+    where: { id: orderId },
+    include: {
+      restaurant: { select: { id: true, name: true } },
+      items: {
+        select: {
+          quantity: true,
+          priceCentsAtPurchase: true,
+          item: { select: { id: true, name: true } },
+        },
+      },
+      checkout: {
+        select: {
+          id: true,
+          createdAt: true,
+          subtotalCents: true,
+          taxCents: true,
+          feeCents: true,
+          totalCents: true,
+        },
+      },
+      user: { select: { id: true } },
+    },
+  })) as unknown as (OrderDetails & { user?: { id: string | null } }) | null;
+
+  if (!order || order.user?.id !== session!.user!.id) {
+    notFound();
+  }
+
+  const shortId = order.id.slice(0, 8);
+  const itemsSubtotal = order.items.reduce(
+    (sum, it) => sum + (it.quantity || 0) * (it.priceCentsAtPurchase || 0),
+    0,
+  );
+  const checkoutSubtotal = order.checkout?.subtotalCents ?? itemsSubtotal;
+  const tax = order.checkout?.taxCents ?? 0;
+  const fee = order.checkout?.feeCents ?? 0;
+  const total = order.checkout?.totalCents ?? order.totalCents;
+
+  return (
+    <div className="mx-auto max-w-4xl p-8">
+      <div className="mb-4">
+        <a href="/profile" className="text-sm text-blue-600 hover:underline">
+          ← Back to profile
+        </a>
+      </div>
+
+      <header className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Order #{shortId}</h1>
+          <p className="mt-1 text-gray-600">
+            Placed on {formatDateTime(new Date(order.createdAt))}
+          </p>
+        </div>
+        <span
+          className={
+            'inline-flex items-center rounded px-2 py-0.5 text-xs ' +
+            (order.status === 'COMPLETED'
+              ? 'bg-green-100 text-green-800'
+              : order.status === 'CANCELLED'
+                ? 'bg-red-100 text-red-800'
+                : 'bg-yellow-100 text-yellow-800')
+          }
+        >
+          {order.status}
+        </span>
+      </header>
+
+      <section className="mb-6 rounded-lg bg-white p-6 shadow">
+        <div className="mb-4">
+          <div className="text-sm text-gray-600">Restaurant</div>
+          <div className="text-lg font-medium text-gray-900">{order.restaurant?.name ?? '-'}</div>
+        </div>
+
+        <div>
+          <div className="mb-2 text-xs font-semibold text-gray-600 uppercase">Items</div>
+          <table className="w-full table-fixed border-collapse text-left text-sm">
+            <colgroup>
+              <col className="w-[55%]" />
+              <col className="w-[15%]" />
+              <col className="w-[15%]" />
+              <col className="w-[15%]" />
+            </colgroup>
+            <thead>
+              <tr className="border-b text-gray-600">
+                <th className="py-2">Name</th>
+                <th className="py-2">Qty</th>
+                <th className="py-2">Unit</th>
+                <th className="py-2">Line total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.items.map((it, i) => {
+                const line = (it.quantity || 0) * (it.priceCentsAtPurchase || 0);
+                return (
+                  <tr key={i} className="border-b last:border-0">
+                    <td className="py-2 text-gray-800">{it.item?.name ?? '-'}</td>
+                    <td className="py-2 text-gray-800">{it.quantity}</td>
+                    <td className="py-2 text-gray-800">{formatCents(it.priceCentsAtPurchase)}</td>
+                    <td className="py-2 font-medium text-gray-900">{formatCents(line)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4 border-t pt-3">
+          <div className="ml-auto w-full max-w-xs text-sm">
+            <div className="flex justify-between py-1 text-gray-700">
+              <span>Subtotal</span>
+              <span>{formatCents(checkoutSubtotal)}</span>
+            </div>
+            {(tax ?? 0) > 0 && (
+              <div className="flex justify-between py-1 text-gray-700">
+                <span>Tax</span>
+                <span>{formatCents(tax)}</span>
+              </div>
+            )}
+            {(fee ?? 0) > 0 && (
+              <div className="flex justify-between py-1 text-gray-700">
+                <span>Fees</span>
+                <span>{formatCents(fee)}</span>
+              </div>
+            )}
+            <div className="flex justify-between border-t pt-2 text-base font-semibold text-gray-900">
+              <span>Total</span>
+              <span>{formatCents(total)}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-lg bg-white p-6 shadow">
+        <h2 className="mb-2 text-lg font-semibold">Payment</h2>
+        {order.checkout ? (
+          <div className="text-sm text-gray-700">
+            <div>
+              Payment session <span className="font-mono">#{order.checkout.id.slice(0, 8)}</span>
+            </div>
+            <div>Created at {formatDateTime(new Date(order.checkout.createdAt))}</div>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-600">No payment information available.</div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/profile/OrderTable.tsx
+++ b/src/components/profile/OrderTable.tsx
@@ -30,11 +30,12 @@ export function OrderTable({ orders }: { orders: OrderRow[] }) {
     <table className="w-full table-fixed border-collapse text-left text-sm">
       <colgroup>
         <col className="w-[16%]" />
-        <col className="w-[20%]" />
+        <col className="w-[16%]" />
         <col className="w-[22%]" />
         <col className="w-[10%]" />
         <col className="w-[12%]" />
-        <col className="w-[20%]" />
+        <col className="w-[14%]" />
+        <col className="w-[16%]" />
       </colgroup>
       <thead>
         <tr className="border-b text-gray-600">
@@ -44,6 +45,7 @@ export function OrderTable({ orders }: { orders: OrderRow[] }) {
           <th className="py-2">Items</th>
           <th className="py-2">Status</th>
           <th className="py-2">Total</th>
+          <th className="py-2"></th>
         </tr>
       </thead>
       <tbody>
@@ -87,10 +89,18 @@ export function OrderTable({ orders }: { orders: OrderRow[] }) {
                   </span>
                 </td>
                 <td className="py-3 font-medium text-gray-900">{formatCents(o.totalCents)}</td>
+                <td className="py-3 text-right">
+                  <a
+                    href={`/profile/orders/${o.id}`}
+                    className="inline-flex items-center rounded border px-2 py-1 text-xs text-gray-700 hover:bg-gray-50"
+                  >
+                    View
+                  </a>
+                </td>
               </tr>
               {isOpen && (
                 <tr className="border-b bg-gray-50/50" aria-live="polite">
-                  <td id={detailsId} colSpan={6} className="py-3">
+                  <td id={detailsId} colSpan={7} className="py-3">
                     <div className="px-2">
                       <div className="mb-2 text-xs font-semibold text-gray-600 uppercase">
                         Items


### PR DESCRIPTION
Added a page to view a single order with items, totals, and payment info. Links to it from the Profile order history. Secures access to the signed‑in user and returns 404 for others.

**Changes:**

- New route: /profile/orders/[id]
- Server-rendered, checks order belongs to current user
- Shows header (short id, status, date), items, subtotal/tax/fees/total, and checkout summary
- Profile table: adds “View” button per order linking to details page

- Tests:
- Order Details: happy path, 404 when not owned, and no-checkout case
- Profile: asserts presence of “View” link URL