### PR TITLE
Order history CSV export + “Export CSV” button on Profile

### DIFF
--- a/src/__tests__/profile/ExportCsv.test.ts
+++ b/src/__tests__/profile/ExportCsv.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/auth', () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    order: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as unknown as { auth: unknown }).auth as ReturnType<typeof vi.fn>),
+    prisma: (dbMod as unknown as { prisma: unknown }).prisma as {
+      order: { findMany: ReturnType<typeof vi.fn> };
+    },
+  };
+}
+
+describe('Export CSV API', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const { auth } = await getMocks();
+    auth.mockResolvedValue(null as any);
+    const mod = await import('@/app/api/profile/orders/export.csv/route');
+    const res = await mod.GET(new Request('http://localhost/api/profile/orders/export.csv'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns CSV with header and rows; respects filters/sort', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } } as any);
+    const now = new Date('2024-01-02T10:00:00Z');
+    prisma.order.findMany.mockResolvedValue([
+      {
+        id: 'ord_1',
+        createdAt: now,
+        status: 'COMPLETED',
+        totalCents: 2599,
+        restaurant: { name: 'Test Resto' },
+        _count: { items: 2 },
+      },
+    ] as any);
+
+    const mod = await import('@/app/api/profile/orders/export.csv/route');
+    const res = await mod.GET(
+      new Request('http://localhost/api/profile/orders/export.csv?status=COMPLETED&sort=oldest'),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/csv');
+    expect(res.headers.get('content-disposition')).toContain('attachment');
+    const text = await res.text();
+    const [header, row] = text.trim().split('\n');
+    expect(header).toBe('order_id,created_at,status,restaurant,items_count,total_cents,currency');
+    expect(row).toContain('ord_1');
+    expect(row).toContain('COMPLETED');
+    expect(row).toContain('Test Resto');
+    expect(row).toContain('2599');
+    expect(row).toContain('EUR');
+
+    // Verify prisma called with filters and sort
+    const args = prisma.order.findMany.mock.calls[0][0];
+    expect(args.where.status).toBe('COMPLETED');
+    expect(args.orderBy.createdAt).toBe('asc');
+  });
+
+  it('returns only header when there are no orders', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'user-1' } } as any);
+    prisma.order.findMany.mockResolvedValue([] as any);
+
+    const mod = await import('@/app/api/profile/orders/export.csv/route');
+    const res = await mod.GET(new Request('http://localhost/api/profile/orders/export.csv'));
+    const text = await res.text();
+    expect(text).toBe('order_id,created_at,status,restaurant,items_count,total_cents,currency\n');
+  });
+});

--- a/src/app/api/profile/orders/export.csv/route.ts
+++ b/src/app/api/profile/orders/export.csv/route.ts
@@ -1,0 +1,88 @@
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+function toCsvRow(values: (string | number | null | undefined)[]) {
+  return values
+    .map((v) => {
+      const s = v == null ? '' : String(v);
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return '"' + s.replace(/"/g, '""') + '"';
+      }
+      return s;
+    })
+    .join(',');
+}
+
+export async function GET(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const sp = url.searchParams;
+  const statusRaw = (sp.get('status') || '').toUpperCase();
+  const validStatuses = new Set(['PENDING', 'COMPLETED', 'CANCELLED']);
+  const statusFilter = validStatuses.has(statusRaw) ? statusRaw : undefined;
+  const fromStr = sp.get('from') || undefined;
+  const toStr = sp.get('to') || undefined;
+  const fromDate = fromStr ? new Date(fromStr) : undefined;
+  const toDate = toStr ? new Date(toStr) : undefined;
+  if (toDate) toDate.setHours(23, 59, 59, 999);
+  const sort = sp.get('sort') === 'oldest' ? 'oldest' : 'newest';
+
+  const where = {
+    customerId: session.user.id as string,
+    ...(statusFilter ? { status: statusFilter as any } : {}),
+    ...(fromDate || toDate
+      ? {
+          createdAt: { ...(fromDate ? { gte: fromDate } : {}), ...(toDate ? { lte: toDate } : {}) },
+        }
+      : {}),
+  } as const;
+  const orderBy = { createdAt: sort === 'oldest' ? 'asc' : 'desc' } as const;
+
+  const orders = await prisma.order.findMany({
+    where,
+    orderBy,
+    select: {
+      id: true,
+      createdAt: true,
+      status: true,
+      totalCents: true,
+      restaurant: { select: { name: true } },
+      _count: { select: { items: true } },
+    },
+  });
+
+  const header = [
+    'order_id',
+    'created_at',
+    'status',
+    'restaurant',
+    'items_count',
+    'total_cents',
+    'currency',
+  ];
+  const rows = orders.map((o) =>
+    toCsvRow([
+      o.id,
+      new Date(o.createdAt).toISOString(),
+      o.status,
+      o.restaurant?.name || '',
+      o._count.items,
+      o.totalCents,
+      'EUR',
+    ]),
+  );
+  const csv = [toCsvRow(header), ...rows].join('\n') + '\n';
+
+  const today = new Date().toISOString().slice(0, 10);
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="orders-${today}.csv"`,
+    },
+  });
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -160,9 +160,25 @@ export default async function ProfilePage({
       <section className="rounded-lg bg-white p-6 shadow">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold">Order History</h2>
-          <span className="text-sm text-gray-500">
-            {totalCount} order{totalCount === 1 ? '' : 's'}
-          </span>
+          <div className="flex items-center gap-3">
+            <a
+              href={(() => {
+                const qp = new URLSearchParams();
+                if (statusFilter) qp.set('status', statusFilter);
+                if (fromStr) qp.set('from', fromStr);
+                if (toStr) qp.set('to', toStr);
+                if (sort === 'oldest') qp.set('sort', 'oldest');
+                const q = qp.toString();
+                return `/api/profile/orders/export.csv${q ? `?${q}` : ''}`;
+              })()}
+              className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
+            >
+              Export CSV
+            </a>
+            <span className="text-sm text-gray-500">
+              {totalCount} order{totalCount === 1 ? '' : 's'}
+            </span>
+          </div>
         </div>
 
         {/* Filters */}


### PR DESCRIPTION
Adds a CSV export endpoint for a user’s order history that respects current filters/sort and a button on the Profile page to download it. Access is restricted to the signed-in user.

**Changes:**

1. API: /api/profile/orders/export.csv

- Auth required; scoped to current user
- Accepts status, from, to, sort; returns text/csv with header row
- Proper filename via Content-Disposition (orders-YYYY-MM-DD.csv)

5. UI: Profile Order History

- Adds “Export CSV” button in header
- Preserves active filters/sort in the export URL

8. Tests

- CSV API: unauthorized (401), happy path (headers + row), filters/sort, empty result returns header only