### PR TITLE
Rda 50 buy item flow create checkout place order

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,13 @@ const eslintConfig = [
   {
     ignores: ['node_modules/**', '.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
   },
+  {
+    files: ['src/**/*.test.*', 'src/**/__tests__/**'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/__tests__/checkout/AddToCheckout.test.ts
+++ b/src/__tests__/checkout/AddToCheckout.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: (fn: any) =>
+      fn({
+        item: { findUnique: vi.fn(), updateMany: vi.fn() },
+        checkout: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+        order: { findFirst: vi.fn(), create: vi.fn(), update: vi.fn() },
+        orderItem: { upsert: vi.fn() },
+      }),
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as any).auth),
+    prisma: (dbMod as any).prisma,
+  };
+}
+
+describe('Add to checkout API', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('401 when unauthenticated', async () => {
+    const { auth } = await getMocks();
+    auth.mockResolvedValue(null);
+    const mod = await import('@/app/api/checkout/add/route');
+    const res = await mod.POST(new Request('http://x/api/checkout/add', { method: 'POST' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('400 when itemId missing', async () => {
+    const { auth } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    const mod = await import('@/app/api/checkout/add/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/add', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when item not found', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.$transaction = (fn: any) =>
+      fn({
+        item: { findUnique: vi.fn().mockResolvedValue(null), updateMany: vi.fn() },
+      });
+    const mod = await import('@/app/api/checkout/add/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/add', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ itemId: 'i1' }),
+      }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('409 when item expired', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.$transaction = (fn: any) =>
+      fn({
+        item: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: 'i1',
+            name: 'Test',
+            restaurantId: 'r1',
+            discountedPriceCents: 100,
+            expiresAt: new Date('2000-01-01T00:00:00Z'),
+            quantityAvailable: 1,
+          }),
+          updateMany: vi.fn(),
+        },
+      });
+    const mod = await import('@/app/api/checkout/add/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/add', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ itemId: 'i1' }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe('Item expired');
+  });
+
+  it('409 when item sold out', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    prisma.$transaction = (fn: any) =>
+      fn({
+        item: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: 'i1',
+            name: 'Test',
+            restaurantId: 'r1',
+            discountedPriceCents: 100,
+            expiresAt: new Date('2099-01-01T00:00:00Z'),
+            quantityAvailable: 0,
+          }),
+          updateMany,
+        },
+      });
+    const mod = await import('@/app/api/checkout/add/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/add', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ itemId: 'i1' }),
+      }),
+    );
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe('Item sold out');
+  });
+});

--- a/src/__tests__/checkout/CheckoutPage.test.tsx
+++ b/src/__tests__/checkout/CheckoutPage.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    checkout: { findFirst: vi.fn() },
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as any).auth),
+    prisma: (dbMod as any).prisma,
+  };
+}
+
+describe('CheckoutPage', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('shows empty state when no pending checkout', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.checkout.findFirst.mockResolvedValue(null);
+    const { default: Page } = await import('@/app/checkout/page');
+    const el = await Page();
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+    expect(html).toContain('Your checkout is empty');
+  });
+
+  it('renders orders and items when checkout exists', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.checkout.findFirst.mockResolvedValue({
+      id: 'c1',
+      subtotalCents: 1000,
+      taxCents: 0,
+      feeCents: 0,
+      totalCents: 1000,
+      orders: [
+        {
+          id: 'o1',
+          restaurant: { name: 'Test Resto' },
+          items: [
+            {
+              quantity: 1,
+              priceCentsAtPurchase: 500,
+              item: { name: 'Burger' },
+            },
+          ],
+          totalCents: 500,
+        },
+      ],
+    });
+    const { default: Page } = await import('@/app/checkout/page');
+    const el = await Page();
+    const html = renderToStaticMarkup(el as unknown as React.ReactElement);
+    expect(html).toContain('Checkout');
+    expect(html).toContain('Test Resto');
+    expect(html).toContain('Burger');
+    expect(html).toContain('Order total');
+  });
+});

--- a/src/__tests__/checkout/FinalizeCheckout.test.ts
+++ b/src/__tests__/checkout/FinalizeCheckout.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/auth', () => ({ auth: vi.fn() }));
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: (fn: any) =>
+      fn({
+        checkout: { findFirst: vi.fn(), update: vi.fn() },
+        order: { updateMany: vi.fn() },
+      }),
+  },
+}));
+
+async function getMocks() {
+  const authMod = await import('@/auth');
+  const dbMod = await import('@/lib/db');
+  return {
+    auth: vi.mocked((authMod as any).auth),
+    prisma: (dbMod as any).prisma,
+  };
+}
+
+describe('Finalize checkout API', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('401 when unauthenticated', async () => {
+    const { auth } = await getMocks();
+    auth.mockResolvedValue(null);
+    const mod = await import('@/app/api/checkout/finalize/route');
+    const res = await mod.POST(new Request('http://x/api/checkout/finalize', { method: 'POST' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('400 when checkoutId missing', async () => {
+    const { auth } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    const mod = await import('@/app/api/checkout/finalize/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/finalize', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('409 when checkout not pending or not owned', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    prisma.$transaction = (fn: any) =>
+      fn({
+        checkout: { findFirst: vi.fn().mockResolvedValue(null), update: vi.fn() },
+        order: { updateMany: vi.fn() },
+      });
+    const mod = await import('@/app/api/checkout/finalize/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/finalize', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ checkoutId: 'c1' }),
+      }),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('200 and redirectUrl on success', async () => {
+    const { auth, prisma } = await getMocks();
+    auth.mockResolvedValue({ user: { id: 'u1' } });
+    const updateMany = vi.fn();
+    const update = vi.fn();
+    prisma.$transaction = (fn: any) =>
+      fn({
+        checkout: { findFirst: vi.fn().mockResolvedValue({ id: 'c1' }), update },
+        order: { updateMany },
+      });
+    const mod = await import('@/app/api/checkout/finalize/route');
+    const res = await mod.POST(
+      new Request('http://x/api/checkout/finalize', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ checkoutId: 'c1' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.redirectUrl).toBe('/profile');
+  });
+});

--- a/src/app/api/checkout/add/route.ts
+++ b/src/app/api/checkout/add/route.ts
@@ -1,0 +1,162 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let itemId: string | undefined;
+  const contentType = req.headers.get('content-type') || '';
+  const accept = req.headers.get('accept') || '';
+  const isForm = contentType.includes('application/x-www-form-urlencoded');
+  const wantsHtml = accept.includes('text/html');
+  if (contentType.includes('application/json')) {
+    const body: unknown = await req.json().catch(() => ({}));
+    const parsed = body as { itemId?: string };
+    itemId = parsed.itemId;
+  } else if (contentType.includes('application/x-www-form-urlencoded')) {
+    const form = await req.formData();
+    itemId = String(form.get('itemId') || '');
+  } else {
+    // Try URL param fallback
+    const url = new URL(req.url);
+    itemId = url.searchParams.get('itemId') || undefined;
+  }
+
+  if (!itemId) {
+    // If browser form or HTML, redirect back to referer with error
+    if (isForm || wantsHtml) {
+      const referer = req.headers.get('referer') || '/restaurants';
+      const u = new URL(referer);
+      u.searchParams.set('error', 'missing');
+      return NextResponse.redirect(u, { status: 303 });
+    }
+    return NextResponse.json({ error: 'Missing itemId' }, { status: 400 });
+  }
+
+  const now = new Date();
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const item = await tx.item.findUnique({
+        where: { id: itemId! },
+        select: {
+          id: true,
+          name: true,
+          restaurantId: true,
+          discountedPriceCents: true,
+          expiresAt: true,
+          quantityAvailable: true,
+        },
+      });
+      if (!item) {
+        return { status: 404 as const, body: { error: 'Item not found' } };
+      }
+      if (!(item.expiresAt > now)) {
+        return { status: 409 as const, body: { error: 'Item expired' } };
+      }
+
+      // Atomically decrement stock if available
+      const dec = await tx.item.updateMany({
+        where: { id: item.id, quantityAvailable: { gt: 0 }, expiresAt: { gt: now } },
+        data: { quantityAvailable: { decrement: 1 } },
+      });
+      if (dec.count === 0) {
+        return { status: 409 as const, body: { error: 'Item sold out' } };
+      }
+
+      // Reuse or create pending checkout
+      let checkout = await tx.checkout.findFirst({
+        where: { customerId: session.user.id, status: 'PENDING' },
+      });
+      if (!checkout) {
+        checkout = await tx.checkout.create({
+          data: {
+            customerId: session.user.id,
+            status: 'PENDING',
+            subtotalCents: 0,
+            taxCents: 0,
+            feeCents: 0,
+            totalCents: 0,
+          },
+        });
+      }
+
+      // Reuse or create order for the restaurant under this checkout
+      let order = await tx.order.findFirst({
+        where: { checkoutId: checkout.id, restaurantId: item.restaurantId },
+      });
+      if (!order) {
+        order = await tx.order.create({
+          data: {
+            checkoutId: checkout.id,
+            restaurantId: item.restaurantId,
+            status: 'PENDING',
+            totalCents: 0,
+            customerId: session.user.id,
+          },
+        });
+      }
+
+      // Upsert order item: increment quantity if already added
+      await tx.orderItem.upsert({
+        where: { orderId_itemId: { orderId: order.id, itemId: item.id } },
+        update: { quantity: { increment: 1 } },
+        create: {
+          orderId: order.id,
+          itemId: item.id,
+          quantity: 1,
+          priceCentsAtPurchase: item.discountedPriceCents,
+        },
+      });
+
+      // Update totals
+      order = await tx.order.update({
+        where: { id: order.id },
+        data: { totalCents: { increment: item.discountedPriceCents } },
+      });
+      checkout = await tx.checkout.update({
+        where: { id: checkout.id },
+        data: {
+          subtotalCents: { increment: item.discountedPriceCents },
+          totalCents: { increment: item.discountedPriceCents },
+        },
+      });
+
+      return { status: 200 as const, body: { checkoutId: checkout.id, redirectUrl: '/checkout' } };
+    });
+
+    // If the client expects HTML (browser form post), redirect appropriately
+    if (isForm || wantsHtml) {
+      if (result.status === 200) {
+        return NextResponse.redirect(new URL(result.body.redirectUrl, req.url), { status: 303 });
+      }
+      const referer = req.headers.get('referer') || '/restaurants';
+      const u = new URL(referer);
+      // map error keys to short codes
+      const code =
+        (result.body as { error?: string })?.error === 'Item sold out'
+          ? 'soldout'
+          : (result.body as { error?: string })?.error === 'Item expired'
+            ? 'expired'
+            : (result.body as { error?: string })?.error === 'Item not found'
+              ? 'notfound'
+              : 'error';
+      u.searchParams.set('error', code);
+      return NextResponse.redirect(u, { status: 303 });
+    }
+
+    return NextResponse.json(result.body, { status: result.status });
+  } catch {
+    if (isForm || wantsHtml) {
+      const referer = req.headers.get('referer') || '/restaurants';
+      const u = new URL(referer);
+      u.searchParams.set('error', 'server');
+      return NextResponse.redirect(u, { status: 303 });
+    }
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/api/checkout/finalize/route.ts
+++ b/src/app/api/checkout/finalize/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const contentType = req.headers.get('content-type') || '';
+  const accept = req.headers.get('accept') || '';
+  const isForm = contentType.includes('application/x-www-form-urlencoded');
+  const wantsHtml = accept.includes('text/html');
+
+  let checkoutId: string | undefined;
+  if (contentType.includes('application/json')) {
+    const body: unknown = await req.json().catch(() => ({}));
+    const parsed = body as { checkoutId?: string };
+    checkoutId = parsed.checkoutId;
+  } else if (isForm) {
+    const form = await req.formData();
+    checkoutId = String(form.get('checkoutId') || '');
+  } else {
+    const url = new URL(req.url);
+    checkoutId = url.searchParams.get('checkoutId') || undefined;
+  }
+  if (!checkoutId) {
+    if (isForm || wantsHtml) {
+      const u = new URL('/checkout', req.url);
+      u.searchParams.set('error', 'missing');
+      return NextResponse.redirect(u, { status: 303 });
+    }
+    return NextResponse.json({ error: 'Missing checkoutId' }, { status: 400 });
+  }
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const checkout = await tx.checkout.findFirst({
+        where: { id: checkoutId, customerId: session.user.id, status: 'PENDING' },
+        select: { id: true },
+      });
+      if (!checkout) {
+        return { status: 409 as const, body: { error: 'Checkout not found or already completed' } };
+      }
+
+      await tx.order.updateMany({
+        where: { checkoutId: checkout.id },
+        data: { status: 'COMPLETED' },
+      });
+      await tx.checkout.update({ where: { id: checkout.id }, data: { status: 'COMPLETED' } });
+
+      // Optionally determine a primary order for redirect; for now profile
+      return { status: 200 as const, body: { redirectUrl: '/profile' } };
+    });
+    if (isForm || wantsHtml) {
+      if (result.status === 200) {
+        const redirectUrl = (result.body as { redirectUrl: string }).redirectUrl;
+        return NextResponse.redirect(new URL(redirectUrl, req.url), {
+          status: 303,
+        });
+      }
+      const u = new URL('/checkout', req.url);
+      u.searchParams.set('error', 'state');
+      return NextResponse.redirect(u, { status: 303 });
+    }
+    return NextResponse.json(result.body, { status: result.status });
+  } catch {
+    if (isForm || wantsHtml) {
+      const u = new URL('/checkout', req.url);
+      u.searchParams.set('error', 'server');
+      return NextResponse.redirect(u, { status: 303 });
+    }
+    return NextResponse.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/src/app/api/profile/orders/export.csv/route.ts
+++ b/src/app/api/profile/orders/export.csv/route.ts
@@ -23,7 +23,9 @@ export async function GET(req: Request) {
   const sp = url.searchParams;
   const statusRaw = (sp.get('status') || '').toUpperCase();
   const validStatuses = new Set(['PENDING', 'COMPLETED', 'CANCELLED']);
-  const statusFilter = validStatuses.has(statusRaw) ? statusRaw : undefined;
+  const statusFilter = validStatuses.has(statusRaw)
+    ? (statusRaw as 'PENDING' | 'COMPLETED' | 'CANCELLED')
+    : undefined;
   const fromStr = sp.get('from') || undefined;
   const toStr = sp.get('to') || undefined;
   const fromDate = fromStr ? new Date(fromStr) : undefined;
@@ -33,7 +35,7 @@ export async function GET(req: Request) {
 
   const where = {
     customerId: session.user.id as string,
-    ...(statusFilter ? { status: statusFilter as any } : {}),
+    ...(statusFilter ? { status: statusFilter } : {}),
     ...(fromDate || toDate
       ? {
           createdAt: { ...(fromDate ? { gte: fromDate } : {}), ...(toDate ? { lte: toDate } : {}) },

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,102 @@
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+export const metadata = { title: 'Checkout | RDA' };
+
+export default async function CheckoutPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+} = {}) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <h1 className="mb-2 text-2xl font-bold">Please sign in</h1>
+        <p>Sign in to view checkout.</p>
+      </div>
+    );
+  }
+
+  const sp = (await (searchParams || Promise.resolve({}))) as Record<
+    string,
+    string | string[] | undefined
+  >;
+  const err = typeof sp.error === 'string' ? sp.error : undefined;
+  const errorText =
+    err === 'state'
+      ? 'Your checkout is not in a valid state.'
+      : err === 'server'
+        ? 'Unexpected error. Please try again.'
+        : err === 'missing'
+          ? 'Missing checkout.'
+          : undefined;
+
+  const checkout = await prisma.checkout.findFirst({
+    where: { customerId: session.user.id, status: 'PENDING' },
+    select: {
+      id: true,
+      subtotalCents: true,
+      taxCents: true,
+      feeCents: true,
+      totalCents: true,
+      orders: {
+        select: {
+          id: true,
+          restaurant: { select: { name: true } },
+          items: {
+            select: {
+              quantity: true,
+              priceCentsAtPurchase: true,
+              item: { select: { name: true } },
+            },
+          },
+          totalCents: true,
+        },
+      },
+    },
+  });
+
+  if (!checkout) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+        <p className="text-gray-600">Your checkout is empty.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-8">
+      <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+      {errorText ? (
+        <div className="mb-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          {errorText}
+        </div>
+      ) : null}
+      <div className="space-y-4">
+        {checkout.orders.map((o) => (
+          <div key={o.id} className="rounded border p-4">
+            <h2 className="mb-2 text-lg font-semibold">{o.restaurant?.name}</h2>
+            <ul className="list-disc pl-5">
+              {o.items.map((it, idx) => (
+                <li key={idx} className="text-sm text-gray-800">
+                  {it.item?.name} × {it.quantity} — €{(it.priceCentsAtPurchase / 100).toFixed(2)}
+                </li>
+              ))}
+            </ul>
+            <div className="mt-2 text-sm font-medium">
+              Order total: €{(o.totalCents / 100).toFixed(2)}
+            </div>
+          </div>
+        ))}
+      </div>
+      <form method="post" action="/api/checkout/finalize" className="mt-6">
+        <input type="hidden" name="checkoutId" value={checkout.id} />
+        <button className="rounded border px-4 py-2 text-sm hover:bg-gray-50" type="submit">
+          Place order
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/restaurants/[slug]/page.tsx
+++ b/src/app/restaurants/[slug]/page.tsx
@@ -3,7 +3,10 @@ import { prisma } from '@/lib/db';
 import { formatCents, formatDateTime } from '@/lib/format';
 import Link from 'next/link';
 
-type Params = { params: { slug: string } };
+type Params = {
+  params: { slug: string };
+  searchParams?: Promise<{ [k: string]: string | string[] | undefined }>;
+};
 
 export async function generateMetadata({ params }: Params) {
   const r = await prisma.restaurant.findUnique({
@@ -13,7 +16,7 @@ export async function generateMetadata({ params }: Params) {
   return { title: r?.name ? `${r.name} | RDA` : 'Restaurant | RDA' };
 }
 
-export default async function RestaurantDetailsPage({ params }: Params) {
+export default async function RestaurantDetailsPage({ params, searchParams }: Params) {
   const now = new Date();
   const restaurant = await prisma.restaurant.findUnique({
     where: { slug: params.slug, isActive: true },
@@ -44,9 +47,36 @@ export default async function RestaurantDetailsPage({ params }: Params) {
   }
 
   const items = restaurant.items;
+  const sp = (await (searchParams || Promise.resolve({}))) as Record<
+    string,
+    string | string[] | undefined
+  >;
+  const err = typeof sp.error === 'string' ? sp.error : undefined;
+  const errorText =
+    err === 'soldout'
+      ? 'Sorry, that item just sold out.'
+      : err === 'expired'
+        ? 'Sorry, that item has expired.'
+        : err === 'notfound'
+          ? 'Item not found.'
+          : err === 'server'
+            ? 'Unexpected error. Please try again.'
+            : err === 'missing'
+              ? 'Missing item.'
+              : undefined;
+  // Read error flag from query if present (Next.js App Router doesn't pass searchParams here by default)
+  // We'll reconstruct from headers via cache of request URL using new URL not available here.
+  // As a simple approach, we show no banner here; instead, the referer redirect lands back with ?error=code
+  // so we render it by accessing process.env.NEXT_RUNTIME hint is not available. Instead, we lean on a clientless pattern:
+  // Next currently doesn't provide searchParams in RSC without signature; to keep this file simple, we won't read it here.
 
   return (
     <div className="mx-auto max-w-6xl p-8">
+      {errorText ? (
+        <div className="mb-4 rounded border border-red-300 bg-red-50 p-3 text-sm text-red-800">
+          {errorText}
+        </div>
+      ) : null}
       <nav className="mb-4 text-sm text-gray-600">
         <Link href="/restaurants" className="hover:underline">
           Restaurants
@@ -112,7 +142,21 @@ export default async function RestaurantDetailsPage({ params }: Params) {
                     Allergens: {it.allergens.map((a) => a.name).join(', ')}
                   </div>
                 ) : null}
-                <div className="mt-3 text-xs text-gray-600">Quantity: {it.quantityAvailable}</div>
+                <div className="mt-3 flex items-center justify-between text-xs text-gray-600">
+                  <span>Quantity: {it.quantityAvailable}</span>
+                  {it.quantityAvailable > 0 ? (
+                    <form method="post" action="/api/checkout/add">
+                      <input type="hidden" name="itemId" value={it.id} />
+                      <button
+                        type="submit"
+                        className="rounded border px-2 py-1 text-xs hover:bg-gray-50"
+                        aria-label={`Buy ${it.name}`}
+                      >
+                        Buy
+                      </button>
+                    </form>
+                  ) : null}
+                </div>
               </li>
             ))}
           </ul>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,7 @@ export async function middleware(request: NextRequest) {
   const isProtectedRoute =
     request.nextUrl.pathname.startsWith('/dashboard') ||
     request.nextUrl.pathname.startsWith('/profile') ||
+    request.nextUrl.pathname.startsWith('/checkout') ||
     request.nextUrl.pathname.includes('/edit') ||
     request.nextUrl.pathname.includes('/create');
 
@@ -33,6 +34,7 @@ export const config = {
   matcher: [
     '/dashboard/:path*',
     '/profile/:path*',
+    '/checkout',
     '/restaurant/create',
     '/restaurant/:path*/edit',
     '/item/create',


### PR DESCRIPTION
**Implemented RDA-50 “Buy item flow” end-to-end:** 
- Add item to checkout with safe stock decrement, then finalize purchase.
- Form-aware 303 redirects for good browser UX.
- New Checkout page with summary and “Place order”.
**Changes:**

**API**

- POST /api/checkout/add
1. Parses JSON, form, or query itemId.
2. Atomic stock decrement via updateMany guard.
3. Reuse/create PENDING Checkout and per-restaurant Order; upsert OrderItem; update totals.
4. Returns JSON for fetch clients; 303 redirects to /checkout for form posts.
5. Redirects back to Referer with ?error=(soldout|expired|notfound|missing|server) on failure.

- POST /api/checkout/finalize
1. Validates PENDING checkout ownership.
2. Marks Orders + Checkout COMPLETED.
3. JSON for fetch clients; 303 redirects to /profile for form posts; error redirects to /checkout?error=(state|missing|server).

**Pages/UI**
- /checkout: Server page showing grouped items and totals; submits finalize via form; displays error banner from ?error.
- /restaurants/[slug]:
1. Adds Buy form (POST to /api/checkout/add) when quantityAvailable > 0.
2. Reads ?error to show minimal error banner.

**Auth/Middleware**
- Protect /checkout like /profile with redirect to sign-in preserving callbackUrl.

**Tests**
- AddToCheckout: 401 unauth, 400 missing itemId, 404 not found, 409 expired, 409 sold-out.
- Finalize: 401 unauth, 400 missing, 409 invalid state, 200 success returns redirectUrl.
- Checkout page: renders empty state and populated state.
