### PR TITLE
Rda 56 local data seeding for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 This is a Next.js 15 App Router project using Auth.js (NextAuth v5) and Prisma with SQLite for local development.
 
 What you’ll get locally:
+
 - Public restaurant catalog and details
 - Auth via GitHub/Google (requires OAuth app keys)
 - Profile with order history (filters/sort/export)
 - Buy flow: add item to checkout and place order
 
 ### 1) Requirements
+
 - Node 20+ and npm
 - VS Code (recommended). Trust the workspace when prompted.
 
 Recommended VS Code extensions:
+
 - ESLint, Prettier, Tailwind CSS IntelliSense
 
 ### 2) Install dependencies
@@ -30,6 +33,7 @@ cp env.example .env.local
 ```
 
 Required minimum for local dev:
+
 - `DATABASE_URL` — keep default `file:./dev.db` for SQLite
 - `NEXTAUTH_SECRET` — generate a random string
 - `NEXTAUTH_URL` — `http://localhost:3000`
@@ -45,10 +49,12 @@ node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 ```
 
 Optional (to sign in with OAuth):
+
 - GitHub: `GITHUB_ID`, `GITHUB_SECRET`
 - Google: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
 
 OAuth callback URLs you’ll need to set in the provider config:
+
 - GitHub callback: `http://localhost:3000/api/auth/callback/github`
 - Google callback: `http://localhost:3000/api/auth/callback/google`
 
@@ -70,11 +76,20 @@ npx prisma studio
 ```
 
 Minimal data to test the buy flow:
+
 - Create a Restaurant (set `isActive = true`).
 - Create at least one Item for that restaurant with:
-	- `discountedPriceCents > 0`
-	- `quantityAvailable > 0`
-	- `expiresAt` in the future
+  - `discountedPriceCents > 0`
+  - `quantityAvailable > 0`
+  - `expiresAt` in the future
+
+Seed convenience (recommended):
+
+```bash
+npm run db:seed
+```
+
+This creates two active restaurants and a few items with stock and future expiries.
 
 ### 5) Run the app
 
@@ -138,3 +153,8 @@ npx prisma migrate reset --force
 - Vitest + Testing Library (jsdom)
 
 Happy hacking!
+
+## Local debug helpers
+
+- Create sample order history for the signed-in user (dev only):
+  - Sign in, then send a POST to `/debug/seed-user-orders` (e.g. via curl or your browser using a tool like REST Client). This will create a completed checkout with a couple of orders and items if restaurants/items exist. Disabled in production.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,13 @@
     "format:check": "prettier --check .",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name init",
+    "db:seed": "prisma db seed",
     "test": "vitest",
     "test:cov": "vitest --coverage",
     "test:ci": "vitest --coverage --run"
+  },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,520 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const now = new Date();
+  const inHours = (h: number) => new Date(now.getTime() + h * 60 * 60 * 1000);
+  const inMinutes = (m: number) => new Date(now.getTime() + m * 60 * 1000);
+  const agoMinutes = (m: number) => new Date(now.getTime() - m * 60 * 1000);
+
+  // Restaurants
+  const restos = [
+    {
+      name: 'Central Bistro',
+      slug: 'central-bistro',
+      address: '1 Main St',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Casual dining in the heart of the city.',
+      imageUrl: null as string | null,
+      isActive: true,
+    },
+    {
+      name: 'Sunset Sushi',
+      slug: 'sunset-sushi',
+      address: '22 River Road',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Fresh rolls and bowls.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'Pasta Palace',
+      slug: 'pasta-palace',
+      address: '7 Olive Lane',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Hearty Italian classics.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'Taco Loco',
+      slug: 'taco-loco',
+      address: '55 Market Ave',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Street-style tacos and sides.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'Green Bowl',
+      slug: 'green-bowl',
+      address: '18 Park Street',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Fresh salads and healthy bowls.',
+      imageUrl: null,
+      isActive: true,
+    },
+    // Active restaurant with no items
+    {
+      name: 'Empty Kitchen',
+      slug: 'empty-kitchen',
+      address: '99 Silent Way',
+      city: 'Riga',
+      country: 'LV',
+      description: 'A restaurant with no items yet.',
+      imageUrl: null,
+      isActive: true,
+    },
+    // Inactive restaurant (should be hidden from catalog)
+    {
+      name: 'Closed Diner',
+      slug: 'closed-diner',
+      address: '404 Gone St',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Temporarily closed for renovation.',
+      imageUrl: null,
+      isActive: false,
+    },
+    {
+      name: 'Nordic Bakery',
+      slug: 'nordic-bakery',
+      address: '12 Birch Road',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Fresh breads and pastries.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'Curry House',
+      slug: 'curry-house',
+      address: '8 Spice Street',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Indian curries and tandoor.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'BBQ Pit',
+      slug: 'bbq-pit',
+      address: '3 Smoke Ave',
+      city: 'Jurmala',
+      country: 'LV',
+      description: 'Low and slow smoked meats.',
+      imageUrl: null,
+      isActive: true,
+    },
+    {
+      name: 'Vegan Deli',
+      slug: 'vegan-deli',
+      address: '21 Greenway',
+      city: 'Riga',
+      country: 'LV',
+      description: 'Plant-based sandwiches and bowls.',
+      imageUrl: null,
+      isActive: true,
+    },
+  ];
+
+  for (const r of restos) {
+    await prisma.restaurant.upsert({
+      where: { slug: r.slug },
+      update: r,
+      create: r,
+    });
+  }
+
+  const slugs = restos.map((r) => r.slug);
+  const restaurants = await prisma.restaurant.findMany({ where: { slug: { in: slugs } } });
+  if (restaurants.length !== restos.length)
+    throw new Error('Seed: restaurants not found after upsert');
+  const bySlug = new Map(restaurants.map((r) => [r.slug, r] as const));
+
+  // Allergens (for diverse items)
+  const allergenNames = ['Gluten', 'Dairy', 'Nuts', 'Seafood', 'Soy', 'Sesame'];
+  for (const name of allergenNames) {
+    await prisma.allergen.upsert({ where: { name }, update: {}, create: { name } });
+  }
+
+  // Items
+  const items = [
+    // Central Bistro
+    {
+      restaurantId: bySlug.get('central-bistro')!.id,
+      name: 'Beef Burger',
+      description: '200g patty, cheddar, pickles',
+      originalPriceCents: 1299,
+      discountedPriceCents: 899,
+      quantityAvailable: 10,
+      expiresAt: inHours(8),
+      imageUrl: null as string | null,
+      allergens: ['Gluten', 'Dairy'],
+    },
+    {
+      restaurantId: bySlug.get('central-bistro')!.id,
+      name: 'Veggie Wrap',
+      description: 'Hummus, grilled veg, spinach',
+      originalPriceCents: 999,
+      discountedPriceCents: 699,
+      quantityAvailable: 6,
+      expiresAt: inHours(6),
+      imageUrl: null,
+      allergens: ['Gluten'],
+    },
+    {
+      restaurantId: bySlug.get('central-bistro')!.id,
+      name: 'Fries',
+      description: 'Crispy skin-on fries',
+      originalPriceCents: 399,
+      discountedPriceCents: 249,
+      quantityAvailable: 3,
+      expiresAt: inMinutes(5), // near expiry
+      imageUrl: null,
+    },
+
+    // Sunset Sushi
+    {
+      restaurantId: bySlug.get('sunset-sushi')!.id,
+      name: 'Salmon Roll',
+      description: '8 pcs',
+      originalPriceCents: 1099,
+      discountedPriceCents: 749,
+      quantityAvailable: 12,
+      expiresAt: inHours(10),
+      imageUrl: null,
+      allergens: ['Seafood', 'Gluten', 'Soy'],
+    },
+    {
+      restaurantId: bySlug.get('sunset-sushi')!.id,
+      name: 'Spicy Tuna Roll',
+      description: '8 pcs, spicy mayo',
+      originalPriceCents: 1199,
+      discountedPriceCents: 799,
+      quantityAvailable: 5,
+      expiresAt: inMinutes(7), // near expiry
+      imageUrl: null,
+      allergens: ['Seafood', 'Gluten', 'Soy'],
+    },
+    {
+      restaurantId: bySlug.get('sunset-sushi')!.id,
+      name: 'Miso Soup',
+      description: 'Tofu, wakame',
+      originalPriceCents: 299,
+      discountedPriceCents: 199,
+      quantityAvailable: 10,
+      expiresAt: inHours(2),
+      imageUrl: null,
+      allergens: ['Soy'],
+    },
+
+    // Pasta Palace
+    {
+      restaurantId: bySlug.get('pasta-palace')!.id,
+      name: 'Spaghetti Carbonara',
+      description: 'Pecorino, pancetta, egg',
+      originalPriceCents: 1399,
+      discountedPriceCents: 949,
+      quantityAvailable: 8,
+      expiresAt: inHours(4),
+      imageUrl: null,
+      allergens: ['Gluten', 'Dairy'],
+    },
+    {
+      restaurantId: bySlug.get('pasta-palace')!.id,
+      name: 'Penne Arrabbiata',
+      description: 'Tomato, chili, garlic',
+      originalPriceCents: 1199,
+      discountedPriceCents: 799,
+      quantityAvailable: 7,
+      expiresAt: inHours(3),
+      imageUrl: null,
+      allergens: ['Gluten'],
+    },
+    {
+      restaurantId: bySlug.get('pasta-palace')!.id,
+      name: 'Garlic Bread',
+      description: 'Herb butter',
+      originalPriceCents: 499,
+      discountedPriceCents: 299,
+      quantityAvailable: 4,
+      expiresAt: inMinutes(9), // near expiry
+      imageUrl: null,
+      allergens: ['Gluten', 'Dairy'],
+    },
+
+    // Taco Loco
+    {
+      restaurantId: bySlug.get('taco-loco')!.id,
+      name: 'Chicken Taco',
+      description: 'Corn tortilla, pico, cilantro',
+      originalPriceCents: 499,
+      discountedPriceCents: 349,
+      quantityAvailable: 15,
+      expiresAt: inHours(5),
+      imageUrl: null,
+    },
+    {
+      restaurantId: bySlug.get('taco-loco')!.id,
+      name: 'Veggie Taco',
+      description: 'Black beans, corn, salsa',
+      originalPriceCents: 449,
+      discountedPriceCents: 299,
+      quantityAvailable: 10,
+      expiresAt: inHours(5),
+      imageUrl: null,
+    },
+    {
+      restaurantId: bySlug.get('taco-loco')!.id,
+      name: 'Churros',
+      description: 'Cinnamon sugar',
+      originalPriceCents: 399,
+      discountedPriceCents: 249,
+      quantityAvailable: 9,
+      expiresAt: inHours(1),
+      imageUrl: null,
+      allergens: ['Gluten'],
+    },
+
+    // Green Bowl
+    {
+      restaurantId: bySlug.get('green-bowl')!.id,
+      name: 'Caesar Salad',
+      description: 'Parmesan, croutons',
+      originalPriceCents: 999,
+      discountedPriceCents: 699,
+      quantityAvailable: 10,
+      expiresAt: inHours(3),
+      imageUrl: null,
+      allergens: ['Dairy', 'Gluten'],
+    },
+    {
+      restaurantId: bySlug.get('green-bowl')!.id,
+      name: 'Quinoa Bowl',
+      description: 'Roasted veg, tahini',
+      originalPriceCents: 1199,
+      discountedPriceCents: 849,
+      quantityAvailable: 8,
+      expiresAt: inHours(6),
+      imageUrl: null,
+    },
+
+    // Nordic Bakery
+    {
+      restaurantId: bySlug.get('nordic-bakery')!.id,
+      name: 'Sourdough Loaf',
+      description: 'Crusty artisan bread',
+      originalPriceCents: 699,
+      discountedPriceCents: 449,
+      quantityAvailable: 0, // sold out
+      expiresAt: inHours(12),
+      imageUrl: null,
+      allergens: ['Gluten'],
+    },
+    {
+      restaurantId: bySlug.get('nordic-bakery')!.id,
+      name: 'Blueberry Muffin',
+      description: 'With crumble topping',
+      originalPriceCents: 399,
+      discountedPriceCents: 249,
+      quantityAvailable: 6,
+      expiresAt: agoMinutes(5), // already expired
+      imageUrl: null,
+      allergens: ['Gluten', 'Dairy'],
+    },
+    {
+      restaurantId: bySlug.get('nordic-bakery')!.id,
+      name: 'Gluten-Free Brownie',
+      description: 'Rich chocolate',
+      originalPriceCents: 449,
+      discountedPriceCents: 299,
+      quantityAvailable: 3,
+      expiresAt: inHours(8),
+      imageUrl: null,
+      allergens: ['Nuts'],
+    },
+
+    // Curry House
+    {
+      restaurantId: bySlug.get('curry-house')!.id,
+      name: 'Chicken Tikka Masala',
+      description: 'Creamy tomato sauce',
+      originalPriceCents: 1399,
+      discountedPriceCents: 999,
+      quantityAvailable: 7,
+      expiresAt: inHours(4),
+      imageUrl: null,
+      allergens: ['Dairy'],
+    },
+    {
+      restaurantId: bySlug.get('curry-house')!.id,
+      name: 'Chana Masala',
+      description: 'Spiced chickpeas',
+      originalPriceCents: 999,
+      discountedPriceCents: 699,
+      quantityAvailable: 10,
+      expiresAt: inHours(6),
+      imageUrl: null,
+    },
+    {
+      restaurantId: bySlug.get('curry-house')!.id,
+      name: 'Garlic Naan',
+      description: 'Buttery and soft',
+      originalPriceCents: 399,
+      discountedPriceCents: 249,
+      quantityAvailable: 5,
+      expiresAt: inMinutes(8),
+      imageUrl: null,
+      allergens: ['Gluten', 'Dairy'],
+    },
+
+    // BBQ Pit
+    {
+      restaurantId: bySlug.get('bbq-pit')!.id,
+      name: 'Pulled Pork Sandwich',
+      description: 'Brioche bun',
+      originalPriceCents: 1199,
+      discountedPriceCents: 849,
+      quantityAvailable: 5,
+      expiresAt: inHours(5),
+      imageUrl: null,
+      allergens: ['Gluten'],
+    },
+    {
+      restaurantId: bySlug.get('bbq-pit')!.id,
+      name: 'Smoked Ribs',
+      description: 'Half rack',
+      originalPriceCents: 1599,
+      discountedPriceCents: 1099,
+      quantityAvailable: 2,
+      expiresAt: agoMinutes(15), // expired
+      imageUrl: null,
+    },
+    {
+      restaurantId: bySlug.get('bbq-pit')!.id,
+      name: 'Coleslaw',
+      description: 'Creamy dressing',
+      originalPriceCents: 299,
+      discountedPriceCents: 199,
+      quantityAvailable: 9,
+      expiresAt: inHours(3),
+      imageUrl: null,
+      allergens: ['Dairy'],
+    },
+
+    // Vegan Deli
+    {
+      restaurantId: bySlug.get('vegan-deli')!.id,
+      name: 'Tofu Banh Mi',
+      description: 'Pickled veg, cilantro',
+      originalPriceCents: 899,
+      discountedPriceCents: 599,
+      quantityAvailable: 6,
+      expiresAt: inHours(4),
+      imageUrl: null,
+      allergens: ['Soy', 'Gluten', 'Sesame'],
+    },
+    {
+      restaurantId: bySlug.get('vegan-deli')!.id,
+      name: 'Kale Caesar (Vegan)',
+      description: 'Cashew dressing',
+      originalPriceCents: 999,
+      discountedPriceCents: 749,
+      quantityAvailable: 4,
+      expiresAt: inHours(5),
+      imageUrl: null,
+      allergens: ['Nuts'],
+    },
+    {
+      restaurantId: bySlug.get('vegan-deli')!.id,
+      name: 'Falafel Bowl',
+      description: 'Tahini sauce',
+      originalPriceCents: 1099,
+      discountedPriceCents: 799,
+      quantityAvailable: 8,
+      expiresAt: inHours(6),
+      imageUrl: null,
+      allergens: ['Sesame'],
+    },
+    {
+      restaurantId: bySlug.get('green-bowl')!.id,
+      name: 'Fruit Cup',
+      description: 'Seasonal mix',
+      originalPriceCents: 499,
+      discountedPriceCents: 349,
+      quantityAvailable: 5,
+      expiresAt: inMinutes(6), // near expiry
+      imageUrl: null,
+    },
+    // Note: no items for 'empty-kitchen' and none for 'closed-diner'
+  ];
+
+  for (const it of items as Array<{
+    restaurantId: string;
+    name: string;
+    description?: string | null;
+    originalPriceCents: number;
+    discountedPriceCents: number;
+    quantityAvailable: number;
+    expiresAt: Date;
+    imageUrl?: string | null;
+    allergens?: string[];
+  }>) {
+    const where = { restaurantId_name: { restaurantId: it.restaurantId, name: it.name } } as const;
+    await prisma.item.upsert({
+      where,
+      update: {
+        description: it.description ?? null,
+        originalPriceCents: it.originalPriceCents,
+        discountedPriceCents: it.discountedPriceCents,
+        quantityAvailable: it.quantityAvailable,
+        expiresAt: it.expiresAt,
+        imageUrl: it.imageUrl ?? null,
+      },
+      create: {
+        restaurantId: it.restaurantId,
+        name: it.name,
+        description: it.description ?? null,
+        originalPriceCents: it.originalPriceCents,
+        discountedPriceCents: it.discountedPriceCents,
+        quantityAvailable: it.quantityAvailable,
+        expiresAt: it.expiresAt,
+        imageUrl: it.imageUrl ?? null,
+        allergens: it.allergens ? { connect: it.allergens.map((a) => ({ name: a })) } : undefined,
+      },
+    });
+
+    // Sync allergens on update
+    if (it.allergens) {
+      await prisma.item.update({
+        where,
+        data: {
+          allergens: {
+            set: [],
+            connect: it.allergens.map((a) => ({ name: a })),
+          },
+        },
+      });
+    }
+  }
+
+  console.log(
+    'Seed complete: diverse restaurants and items created (near-expiry, expired, sold-out, allergens).',
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/debug/seed-user-orders/route.ts
+++ b/src/app/debug/seed-user-orders/route.ts
@@ -1,0 +1,102 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/auth';
+import { prisma } from '@/lib/db';
+
+export async function POST() {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Disabled in production' }, { status: 403 });
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const userId = session.user.id;
+
+  // Use two restaurants if available
+  const restaurants = await prisma.restaurant.findMany({
+    where: { isActive: true },
+    select: { id: true },
+    take: 2,
+  });
+  if (restaurants.length === 0) {
+    return NextResponse.json(
+      { error: 'No restaurants found. Run prisma seed first.' },
+      { status: 400 },
+    );
+  }
+
+  // Create a completed checkout with two orders and some items
+  const items = await prisma.item.findMany({
+    where: { restaurantId: { in: restaurants.map((r) => r.id) } },
+    take: 3,
+    select: { id: true, restaurantId: true, discountedPriceCents: true },
+  });
+  if (items.length === 0) {
+    return NextResponse.json({ error: 'No items found. Seed items first.' }, { status: 400 });
+  }
+
+  const result = await prisma.$transaction(async (tx) => {
+    const checkout = await tx.checkout.create({
+      data: {
+        customerId: userId,
+        status: 'COMPLETED',
+        subtotalCents: 0,
+        taxCents: 0,
+        feeCents: 0,
+        totalCents: 0,
+      },
+    });
+
+    const byResto = new Map<string, { total: number; itemIds: { id: string; price: number }[] }>();
+    for (const it of items) {
+      const entry = byResto.get(it.restaurantId) || { total: 0, itemIds: [] };
+      entry.total += it.discountedPriceCents;
+      entry.itemIds.push({ id: it.id, price: it.discountedPriceCents });
+      byResto.set(it.restaurantId, entry);
+    }
+
+    for (const [restaurantId, data] of byResto.entries()) {
+      const order = await tx.order.create({
+        data: {
+          checkoutId: checkout.id,
+          restaurantId,
+          status: 'COMPLETED',
+          totalCents: 0,
+          customerId: userId,
+        },
+      });
+
+      for (const i of data.itemIds) {
+        await tx.orderItem.create({
+          data: {
+            orderId: order.id,
+            itemId: i.id,
+            quantity: 1,
+            priceCentsAtPurchase: i.price,
+          },
+        });
+        await tx.order.update({
+          where: { id: order.id },
+          data: { totalCents: { increment: i.price } },
+        });
+        await tx.checkout.update({
+          where: { id: checkout.id },
+          data: {
+            subtotalCents: { increment: i.price },
+            totalCents: { increment: i.price },
+          },
+        });
+      }
+    }
+
+    return checkout.id;
+  });
+
+  return NextResponse.json({
+    ok: true,
+    message: 'Created sample completed orders',
+    checkoutId: result,
+  });
+}

--- a/src/app/restaurants/[slug]/page.tsx
+++ b/src/app/restaurants/[slug]/page.tsx
@@ -3,23 +3,25 @@ import { prisma } from '@/lib/db';
 import { formatCents, formatDateTime } from '@/lib/format';
 import Link from 'next/link';
 
-type Params = {
-  params: { slug: string };
+type PageProps = {
+  params: Promise<{ slug: string }>;
   searchParams?: Promise<{ [k: string]: string | string[] | undefined }>;
 };
 
-export async function generateMetadata({ params }: Params) {
-  const r = await prisma.restaurant.findUnique({
-    where: { slug: params.slug, isActive: true },
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const r = await prisma.restaurant.findFirst({
+    where: { slug, isActive: true },
     select: { name: true },
   });
   return { title: r?.name ? `${r.name} | RDA` : 'Restaurant | RDA' };
 }
 
-export default async function RestaurantDetailsPage({ params, searchParams }: Params) {
+export default async function RestaurantDetailsPage({ params, searchParams }: PageProps) {
+  const { slug } = await params;
   const now = new Date();
-  const restaurant = await prisma.restaurant.findUnique({
-    where: { slug: params.slug, isActive: true },
+  const restaurant = await prisma.restaurant.findFirst({
+    where: { slug, isActive: true },
     select: {
       id: true,
       name: true,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -15,6 +15,7 @@ export async function middleware(request: NextRequest) {
     request.nextUrl.pathname.startsWith('/dashboard') ||
     request.nextUrl.pathname.startsWith('/profile') ||
     request.nextUrl.pathname.startsWith('/checkout') ||
+    request.nextUrl.pathname.startsWith('/debug') ||
     request.nextUrl.pathname.includes('/edit') ||
     request.nextUrl.pathname.includes('/create');
 
@@ -35,6 +36,7 @@ export const config = {
     '/dashboard/:path*',
     '/profile/:path*',
     '/checkout',
+    '/debug/:path*',
     '/restaurant/create',
     '/restaurant/:path*/edit',
     '/item/create',


### PR DESCRIPTION
Seed: Add seeder with diverse data (active/inactive restaurants, empty restaurant, near-expiry/expired/sold-out items, allergens) and wire npm run db:seed.
Debug: New dev-only endpoint POST /debug/seed-user-orders to create sample completed orders for the signed-in user; protect /debug/* in middleware.
Restaurants: Fix [slug] page to await async in metadata and query.
Docs: Update README with seeding instructions and debug helper usage.