### PR TITLE
Rda 62 remove empty orders from pending checkout

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -89,6 +89,17 @@ export default async function CheckoutPage({
     );
   }
 
+  // Filter out any orders that may have become empty
+  const orders = checkout.orders.filter((o) => o.items.length > 0);
+  if (orders.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl p-8 text-center">
+        <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
+        <p className="text-gray-600">Your checkout is empty.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto max-w-3xl p-8">
       <h1 className="mb-4 text-2xl font-bold">Checkout</h1>
@@ -98,7 +109,7 @@ export default async function CheckoutPage({
         </div>
       ) : null}
       <div className="space-y-4">
-        {checkout.orders.map((o) => (
+        {orders.map((o) => (
           <div key={o.id} className="rounded border p-4">
             <h2 className="mb-2 text-lg font-semibold">{o.restaurant?.name}</h2>
             <ul className="pl-1">


### PR DESCRIPTION
Fixes a UX bug where a Pending order with zero items remained visible. When the last item is removed, the order is deleted; the Checkout page no longer renders zero‑item orders.

**Changes:**

- API: Delete order when an item is removed and no items remain (decrement-to-zero or DELETE). Guard the cleanup to run only after deletions.

- UI: Filter out zero‑item orders on Checkout and show the empty state if none remain.
