### PR TITLE
Rda 63 add add to cart on restaurant items

### DIFF
--- a/src/__tests__/checkout/ItemsApi.test.ts
+++ b/src/__tests__/checkout/ItemsApi.test.ts
@@ -156,7 +156,11 @@ describe('Checkout items API', () => {
           findFirst: vi.fn().mockResolvedValue({ id: 'c1' }),
           update: vi.fn().mockResolvedValue({ id: 'c1' }),
         },
-        order: { findFirst: vi.fn().mockResolvedValue({ id: 'o1' }), update: vi.fn(), delete: vi.fn() },
+        order: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'o1' }),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
         orderItem: {
           findUnique: vi.fn().mockResolvedValue({ quantity: 2, priceCentsAtPurchase: 250 }),
           delete: vi.fn(),
@@ -210,7 +214,11 @@ describe('Checkout items API', () => {
           findFirst: vi.fn().mockResolvedValue({ id: 'c1' }),
           update: vi.fn().mockResolvedValue({ id: 'c1' }),
         },
-        order: { findFirst: vi.fn().mockResolvedValue({ id: 'o1' }), update: vi.fn(), delete: vi.fn() },
+        order: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'o1' }),
+          update: vi.fn(),
+          delete: vi.fn(),
+        },
         orderItem: {
           findUnique: vi.fn().mockResolvedValue({ quantity: 1, priceCentsAtPurchase: 250 }),
           update: vi.fn(),

--- a/src/__tests__/restaurants/AddToCartButton.test.tsx
+++ b/src/__tests__/restaurants/AddToCartButton.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AddToCartButton from '@/components/restaurants/AddToCartButton';
+
+describe('AddToCartButton', () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+  afterEach(() => {
+    global.fetch = originalFetch as any;
+  });
+
+  it('adds to cart without redirect and emits count', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ count: 3 }), { status: 200 }));
+    const spy = vi.fn();
+    window.addEventListener('checkout:count', spy as EventListener);
+    render(<AddToCartButton itemId="i1" />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(screen.getByText(/added/i)).toBeInTheDocument();
+  });
+
+  it('shows error message on soldout', async () => {
+    (global.fetch as any).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'soldout' }), { status: 409 }) as any,
+    );
+    render(<AddToCartButton itemId="i1" />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(screen.getByText(/sold out/i)).toBeInTheDocument());
+  });
+});

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -49,6 +49,7 @@ export default async function CheckoutPage({
       feeCents: true,
       totalCents: true,
       orders: {
+        where: { items: { some: {} } },
         select: {
           id: true,
           restaurant: { select: { name: true } },

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -84,9 +84,10 @@ export default async function ProfilePage({
   };
   const skip = (page - 1) * pageSize;
 
+  const whereWithItems = { ...where, items: { some: {} } } as const;
   const [orders, totalCount, accounts] = await Promise.all([
     prisma.order.findMany({
-      where,
+      where: whereWithItems,
       orderBy,
       skip,
       take: pageSize,
@@ -105,7 +106,7 @@ export default async function ProfilePage({
         },
       },
     }) as Promise<OrderRow[]>,
-    prisma.order.count({ where }),
+    prisma.order.count({ where: whereWithItems }),
     prisma.account.findMany({
       where: { userId: session.user.id },
       select: { provider: true, providerAccountId: true },

--- a/src/app/restaurants/[slug]/page.tsx
+++ b/src/app/restaurants/[slug]/page.tsx
@@ -3,6 +3,8 @@ import { prisma } from '@/lib/db';
 import { formatCents, formatDateTime } from '@/lib/format';
 import Link from 'next/link';
 import Countdown from '@/components/restaurants/Countdown';
+import AddToCartButton from '@/components/restaurants/AddToCartButton';
+import QuantityLive from '@/components/restaurants/QuantityLive';
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -158,18 +160,23 @@ export default async function RestaurantDetailsPage({ params, searchParams }: Pa
                   </div>
                 ) : null}
                 <div className="mt-3 flex items-center justify-between text-xs text-gray-600">
-                  <span>Quantity: {it.quantityAvailable}</span>
+                  <span>
+                    Quantity: <QuantityLive itemId={it.id} initial={it.quantityAvailable} />
+                  </span>
                   {it.quantityAvailable > 0 ? (
-                    <form method="post" action="/api/checkout/add">
-                      <input type="hidden" name="itemId" value={it.id} />
-                      <button
-                        type="submit"
-                        className="rounded border px-2 py-1 text-xs hover:bg-gray-50"
-                        aria-label={`Buy ${it.name}`}
-                      >
-                        Buy
-                      </button>
-                    </form>
+                    <div className="flex items-center gap-2">
+                      <form method="post" action="/api/checkout/add">
+                        <input type="hidden" name="itemId" value={it.id} />
+                        <button
+                          type="submit"
+                          className="rounded border px-2 py-1 text-xs hover:bg-gray-50"
+                          aria-label={`Buy ${it.name}`}
+                        >
+                          Buy
+                        </button>
+                      </form>
+                      <AddToCartButton itemId={it.id} available={it.quantityAvailable} />
+                    </div>
                   ) : null}
                 </div>
               </li>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -16,11 +16,17 @@ function useCheckoutCount() {
         if (!cancelled) setCount(data.count ?? 0);
       } catch {}
     }
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { count?: number };
+      if (typeof detail?.count === 'number') setCount(detail.count);
+    };
     load();
     const id = setInterval(load, 10_000);
+    window.addEventListener('checkout:count', handler as EventListener);
     return () => {
       cancelled = true;
       clearInterval(id);
+      window.removeEventListener('checkout:count', handler as EventListener);
     };
   }, []);
   return count;

--- a/src/components/restaurants/AddToCartButton.tsx
+++ b/src/components/restaurants/AddToCartButton.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type Props = {
+  itemId: string;
+  disabled?: boolean;
+  available?: number;
+};
+
+export default function AddToCartButton({ itemId, disabled, available }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [left, setLeft] = useState<number | null>(typeof available === 'number' ? available : null);
+  const timer = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current);
+    };
+  }, []);
+
+  const showTemp = useCallback((text: string) => {
+    setMsg(text);
+    if (timer.current) window.clearTimeout(timer.current);
+    timer.current = window.setTimeout(() => setMsg(null), 1500);
+  }, []);
+
+  const onClick = useCallback(async () => {
+    if (disabled || loading) return;
+    if (left !== null && left <= 0) return;
+    setLoading(true);
+    try {
+      const res = await fetch('/api/checkout/add', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+        },
+        body: JSON.stringify({ itemId }),
+      });
+      if (!res.ok) {
+        // parse and map API error
+        let code: 'soldout' | 'expired' | 'notfound' | 'unauth' | 'error' = 'error';
+        try {
+          const data = (await res.json()) as any;
+          const msg: string = typeof data?.error === 'string' ? data.error.toLowerCase() : '';
+          if (msg.includes('sold out')) code = 'soldout';
+          else if (msg.includes('expired')) code = 'expired';
+          else if (msg.includes('not found')) code = 'notfound';
+          else if (msg.includes('unauthorized')) code = 'unauth';
+        } catch {}
+        if (code === 'error') {
+          if (res.status === 401) code = 'unauth';
+          else if (res.status === 404) code = 'notfound';
+          else if (res.status === 409) code = 'soldout';
+        }
+        if (code === 'soldout') showTemp('Sold out');
+        else if (code === 'expired') showTemp('Expired');
+        else if (code === 'notfound') showTemp('Not available');
+        else if (code === 'unauth') showTemp('Sign in required');
+        else showTemp('Error');
+        return;
+      }
+      showTemp('Added');
+      // Optimistically lower local available and notify others on page
+      try {
+        window.dispatchEvent(
+          new CustomEvent('checkout:item-delta', { detail: { itemId, delta: -1 } }),
+        );
+      } catch {}
+      if (left !== null) setLeft(Math.max(0, left - 1));
+      // Refresh count and notify navbar for immediate update
+      try {
+        const c = await fetch('/api/checkout/count', { cache: 'no-store' });
+        const data = (await c.json()) as { count?: number };
+        window.dispatchEvent(
+          new CustomEvent('checkout:count', { detail: { count: data.count ?? 0 } }),
+        );
+      } catch {}
+    } finally {
+      setLoading(false);
+    }
+  }, [itemId, disabled, loading, left, showTemp]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        className="rounded border px-2 py-1 text-xs hover:bg-gray-50 disabled:opacity-50"
+        aria-label="Add to cart"
+        onClick={onClick}
+        disabled={!!disabled || loading || (left !== null && left <= 0)}
+      >
+        {loading ? 'Adding…' : 'Add to cart'}
+      </button>
+      <span aria-live="polite" className="text-xs text-gray-600">
+        {msg}
+      </span>
+    </div>
+  );
+}

--- a/src/components/restaurants/QuantityLive.tsx
+++ b/src/components/restaurants/QuantityLive.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Props = { itemId: string; initial: number };
+
+export default function QuantityLive({ itemId, initial }: Props) {
+  const [qty, setQty] = useState(initial);
+
+  useEffect(() => {
+    const onDelta = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { itemId?: string; delta?: number };
+      if (detail?.itemId === itemId && typeof detail.delta === 'number') {
+        const d = detail.delta as number;
+        setQty((q) => Math.max(0, q + d));
+      }
+    };
+    window.addEventListener('checkout:item-delta', onDelta as EventListener);
+    return () => window.removeEventListener('checkout:item-delta', onDelta as EventListener);
+  }, [itemId]);
+
+  return <span data-testid={`qty-${itemId}`}>{qty}</span>;
+}


### PR DESCRIPTION
Added “Add to cart” on restaurant items without redirect, live-updates visible stock and navbar badge, and fixed empty orders so they don’t appear in checkout or profile.

**Changes:**
- UI:
1. New AddToCartButton 
2. New QuantityLive to live update Quantity
3. Navbar listens for badge updates
- API:
1. Delete Order when last Item removed
- Tests:
1. AddToCartButton tests

