### PR TITLE
fix(auth): redirect HTML/form add-to-checkout requests to /auth/signi…

### DIFF
--- a/src/__tests__/restaurants/AddToCartButton.test.tsx
+++ b/src/__tests__/restaurants/AddToCartButton.test.tsx
@@ -31,4 +31,24 @@ describe('AddToCartButton', () => {
     fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
     await waitFor(() => expect(screen.getByText(/sold out/i)).toBeInTheDocument());
   });
+
+  it('redirects to sign-in on 401', async () => {
+    const originalLocation = window.location as any;
+    // @ts-ignore test override
+    delete window.location;
+    const assign = vi.fn();
+    // @ts-ignore test override
+    window.location = { href: 'http://localhost/', assign };
+
+    (global.fetch as any).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+    );
+    render(<AddToCartButton itemId="i1" />);
+    fireEvent.click(screen.getByRole('button', { name: /add to cart/i }));
+    await waitFor(() => expect(assign).toHaveBeenCalled());
+
+    // restore
+    // @ts-ignore test override
+    window.location = originalLocation;
+  });
 });

--- a/src/components/restaurants/AddToCartButton.tsx
+++ b/src/components/restaurants/AddToCartButton.tsx
@@ -55,10 +55,18 @@ export default function AddToCartButton({ itemId, disabled, available }: Props) 
           else if (res.status === 404) code = 'notfound';
           else if (res.status === 409) code = 'soldout';
         }
-        if (code === 'soldout') showTemp('Sold out');
+        if (code === 'unauth') {
+          try {
+            const current = window.location.href;
+            const url = `/auth/signin?callbackUrl=${encodeURIComponent(current)}`;
+            // Prefer assign to keep history and allow back
+            window.location.assign(url);
+          } catch {
+            showTemp('Sign in required');
+          }
+        } else if (code === 'soldout') showTemp('Sold out');
         else if (code === 'expired') showTemp('Expired');
         else if (code === 'notfound') showTemp('Not available');
-        else if (code === 'unauth') showTemp('Sign in required');
         else showTemp('Error');
         return;
       }


### PR DESCRIPTION
Improve unauthorized UX for “Buy” and “Add to cart” by redirecting users to sign-in instead of showing a raw 401 error.

**Changes:**

- API: /checkout/add redirects unauthorized to /signin
- UI: AddToCartButton redirects unauthorized to /signin